### PR TITLE
Fix calculation to apply taxes after discount

### DIFF
--- a/src/calculator.test.js
+++ b/src/calculator.test.js
@@ -10,6 +10,7 @@ test('no taxes', () => {
   expect(price.subtotal).toBe(100);
   expect(price.taxes).toBe(0);
   expect(price.discount).toBe(0);
+  expect(price.netTotal).toBe(100);
   expect(price.total).toBe(100);
 });
 
@@ -18,6 +19,7 @@ test('fixed vat', () => {
   expect(price.subtotal).toBe(100);
   expect(price.taxes).toBe(9);
   expect(price.discount).toBe(0);
+  expect(price.netTotal).toBe(100);
   expect(price.total).toBe(109);
 })
 
@@ -26,6 +28,7 @@ test('fixed vat when prices include taxes', () => {
   expect(price.subtotal).toBe(92);
   expect(price.taxes).toBe(8);
   expect(price.discount).toBe(0);
+  expect(price.netTotal).toBe(92);
   expect(price.total).toBe(100);
 });
 
@@ -35,6 +38,7 @@ test('fixed vat when prices include taxes', () => {
   expect(price.subtotal).toBe(41583);
   expect(price.taxes).toBe(8317);
   expect(price.discount).toBe(0);
+  expect(price.netTotal).toBe(41583);
   expect(price.total).toBe(49900);
 });
 
@@ -46,6 +50,7 @@ test('fixed vat when prices include taxes for a real example', () => {
   expect(price.subtotal).toBe(2710);
   expect(price.taxes).toBe(190);
   expect(price.discount).toBe(0);
+  expect(price.netTotal).toBe(2710);
   expect(price.total).toBe(2900);
 });
 
@@ -55,6 +60,7 @@ test('country based VAT', () => {
   expect(price.subtotal).toBe(100);
   expect(price.taxes).toBe(21);
   expect(price.discount).toBe(0);
+  expect(price.netTotal).toBe(100);
   expect(price.total).toBe(121);
 });
 
@@ -64,6 +70,7 @@ test('country based VAT when prices include taxes', () => {
   expect(price.subtotal).toBe(83);
   expect(price.taxes).toBe(17);
   expect(price.discount).toBe(0);
+  expect(price.netTotal).toBe(83);
   expect(price.total).toBe(100);
 });
 
@@ -72,22 +79,25 @@ test('coupon with no taxes', () => {
   expect(price.subtotal).toBe(100);
   expect(price.taxes).toBe(0);
   expect(price.discount).toBe(10);
+  expect(price.netTotal).toBe(90);
   expect(price.total).toBe(90);
 });
 
 test('coupon with vat', () => {
-  const price = calculatePrices(null, null, "USA", "USD", {percentage: 10, product_types: ["test"]}, [{price: {cents: 100}, vat: 9, type: "test"}]);
+  const price = calculatePrices(null, null, "USA", "USD", {percentage: 10, product_types: ["test"]}, [{price: {cents: 100}, vat: 10, type: "test"}]);
   expect(price.subtotal).toBe(100);
   expect(price.taxes).toBe(9);
   expect(price.discount).toBe(10);
+  expect(price.netTotal).toBe(90);
   expect(price.total).toBe(99);
 });
 
 test('coupon with vat when prices include taxes', () => {
   const price = calculatePrices({prices_include_taxes: true}, null, "USA", "USD", {percentage: 10, product_types: ["test"]}, [{price: {cents: 100}, vat: 9, type: "test"}]);
   expect(price.subtotal).toBe(92);
-  expect(price.taxes).toBe(8);
+  expect(price.taxes).toBe(7);
   expect(price.discount).toBe(10);
+  expect(price.netTotal).toBe(83);
   expect(price.total).toBe(90);
 });
 
@@ -110,15 +120,17 @@ test('pricing items', () => {
   expect(price.subtotal).toBe(100);
   expect(price.taxes).toBe(10);
   expect(price.discount).toBe(0);
+  expect(price.netTotal).toBe(100);
   expect(price.total).toBe(110);
 });
 
 test('quantity', () => {
   const price = calculatePrices(null, null, "USA", "USD", {percentage: 10, product_types: ["test"]}, [{price: {cents: 100}, quantity: 2, vat: 9, type: "test"}]);
   expect(price.subtotal).toBe(200);
-  expect(price.taxes).toBe(18);
+  expect(price.taxes).toBe(16);
   expect(price.discount).toBe(20);
-  expect(price.total).toBe(198);
+  expect(price.netTotal).toBe(180);
+  expect(price.total).toBe(196);
 });
 
 test('member discounts', () => {
@@ -139,8 +151,8 @@ test('member discounts', () => {
   expect(price.subtotal).toBe(100);
   expect(price.taxes).toBe(0);
   expect(price.discount).toBe(10);
+  expect(price.netTotal).toBe(90);
   expect(price.total).toBe(90);
-
 });
 
 test('fixed member discounts', () => {
@@ -162,6 +174,7 @@ test('fixed member discounts', () => {
   expect(price.subtotal).toBe(2490);
   expect(price.taxes).toBe(0);
   expect(price.discount).toBe(1500);
+  expect(price.netTotal).toBe(990);
   expect(price.total).toBe(990);
 });
 
@@ -184,5 +197,118 @@ test('fixed member discounts', () => {
   expect(price.subtotal).toBe(2490);
   expect(price.taxes).toBe(0);
   expect(price.discount).toBe(1500);
+  expect(price.netTotal).toBe(990);
   expect(price.total).toBe(990);
+});
+
+test('real world tax calculation', () => {
+  const settings = {
+    "prices_include_taxes": true,
+    "taxes": [
+      {
+        "percentage": 7,
+        "product_types": "book",
+        "countries": "USA",
+      },
+      {
+        "percentage": 19,
+        "product_types": "ebook",
+        "countries": "USA",
+      },
+    ],
+  };
+
+  const firstItem = {
+    price: {cents: 2900, items: [{cents: 1900, type: "book"}, {cents: 1000, type: "ebook"}]},
+    type: "book"
+  };
+  const secondItem = {
+    price: {cents: 3490, items: [{cents: 2300, type: "book"}, {cents: 1190, type: "ebook"}]},
+    type: "book"
+  };
+
+  const price = calculatePrices(
+    settings, null, "USA", "USD", null,
+    [firstItem, secondItem]
+  );
+  expect(price.subtotal).toBe(5766);
+  expect(price.taxes).toBe(625);
+  expect(price.discount).toBe(0);
+  expect(price.netTotal).toBe(5766);
+  expect(price.total).toBe(6391);
+});
+
+test('real world relative discount with taxes', () => {
+  const settings = {
+    "prices_include_taxes": true,
+    "taxes": [
+      {
+        "percentage": 7,
+        "product_types": "book",
+        "countries": "USA",
+      },
+      {
+        "percentage": 19,
+        "product_types": "ebook",
+        "countries": "USA",
+      },
+    ],
+  };
+
+  const firstItem = {
+    price: {cents: 3900, items: [{cents: 2900, type: "book"}, {cents: 1000, type: "ebook"}]},
+    type: "book"
+  };
+
+  const price = calculatePrices(
+    settings, null, "USA", "USD", {percentage: 25, product_types: ["book"]},
+    [firstItem]
+  );
+  expect(price.subtotal).toBe(3550);
+  expect(price.taxes).toBe(262);
+  expect(price.discount).toBe(975);
+  expect(price.netTotal).toBe(2663);
+  expect(price.total).toBe(2925);
+});
+
+test('real world fixed member discount with taxes', () => {
+  const settings = {
+    "prices_include_taxes": true,
+    "taxes": [
+      {
+        "percentage": 7,
+        "product_types": "book",
+        "countries": "USA",
+      },
+      {
+        "percentage": 19,
+        "product_types": "ebook",
+        "countries": "USA",
+      },
+    ],
+    "member_discounts": [
+      {
+        "claims": {"app_metadata.subscription.plan": "member"},
+        "fixed": [{"amount": "10.00", "currency": "USD"}],
+        "product_types": ["book"]
+      }
+    ]
+  };
+
+  const firstItem = {
+    price: {cents: 3900, items: [{cents: 2900, type: "book"}, {cents: 1000, type: "ebook"}]},
+    type: "book"
+  };
+
+  const price = calculatePrices(
+    settings,
+    {app_metadata: {subscription: {plan: "member"}}},
+    "USA", "USD", null,
+    [firstItem]
+  );
+  expect(price.subtotal).toBe(3550);
+  expect(price.taxes).toBe(260);
+  expect(price.discount).toBe(1000);
+  expect(price.netTotal).toBe(2640);
+  expect(price.total).toBe(2900);
 });

--- a/src/index.js
+++ b/src/index.js
@@ -179,6 +179,7 @@ export default class GoCommerce {
     cart.discount = priceObject(price.discount, this.currency);
     cart.couponDiscount = priceObject(price.couponDiscount, this.currency);
     cart.memberDiscount = priceObject(price.memberDiscount, this.currency);
+    cart.netTotal = priceObject(price.netTotal, this.currency);
     cart.taxes = priceObject(price.taxes, this.currency);
     cart.total = priceObject(price.total, this.currency);
 


### PR DESCRIPTION
*Fixes #16*

This PR replicates https://github.com/netlify/gocommerce/pull/155 for the JS lib.
The tests have been synced manually to verify similar behavior.