### PR TITLE
chore: add initial stalebot config

### DIFF
--- a/.github/workflows/stalebot.yml
+++ b/.github/workflows/stalebot.yml
@@ -1,0 +1,18 @@
+name: 'Mark and close stale issues in the repo'
+on:
+  schedule:
+    - cron: '30 1 * * *' # runs daily at 1:30 https://crontab.guru/#30_1_*_*_*
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3.0.18
+        with:
+          exempt-issue-labels: 'WIP,security,action_item,never_stale'
+          days-before-issue-stale: 365
+          stale-issue-label: 'stale'
+          stale-issue-message: 'This issue has been automatically marked as stale because it has not had activity in 1 year. It will be closed in 7 days if no further activity occurs. Thanks!'
+          days-before-issue-close: 7
+          close-issue-message: 'This issue was closed because it had no activity for over 60 days.'
+          days-before-pr-close: -1


### PR DESCRIPTION
NOTICE: If this pull request does not apply to your repository, feel free to close this pull request. This is a pull request generated by [github-tools](https://github.com/netlify/github-tools/) to add an initial stalebot config. It is setup to currently close any issues that are older than 1 year with 7 days notice. If you'd like to change it, feel free to.